### PR TITLE
feat: add oarepo-feature-community-header to invenio-rdm-records

### DIFF
--- a/invenio-forks.yaml
+++ b/invenio-forks.yaml
@@ -156,6 +156,8 @@ packages:
         base: v22.7.3
       - name: oarepo-feature-review-before-doi-assign
         base: v22.7.3
+      - name: oarepo-feature-community-header
+        base: v28.0.0
     entrypoints:
       - remove:
           # - group: flask.commands


### PR DESCRIPTION
https://github.com/oarepo/invenio-rdm-records/commits/oarepo-contribution-community-header/ 

Is it OK to base off of v28? I think yes, because we will switch to it soon

merged upstream