### PR TITLE
Register oarepo-feature-quota-drop-parent-fk (invenio-rdm-records)

### DIFF
--- a/invenio-forks.yaml
+++ b/invenio-forks.yaml
@@ -131,6 +131,8 @@ packages:
         base: v22.7.3
       - name: oarepo-feature-review-before-doi-assign
         base: v22.7.3
+      - name: oarepo-feature-quota-drop-parent-fk
+        base: v32.0.0
     entrypoints:
       - remove:
           - group: invenio_search.mappings


### PR DESCRIPTION
Registers a new invenio-rdm-records fork feature branch: **`oarepo-feature-quota-drop-parent-fk`** (base `v32.0.0`).

### What the fork branch does
`rdm_records_quota.parent_id` has a foreign key to `rdm_parents_metadata`, which only holds standard RDM records. oarepo custom models (e.g. datasets) keep their parents in their own `*_parent_metadata` tables, so `set_quota` fails with a `ForeignKeyViolation` for them.

The branch replaces that FK with a plain **indexed + unique** column (in the model and in the create migration `faf0cefa79a0`), so per-record quota overrides can be stored for any model. The unique constraint still provides the `parent_id` lookup index; the trade-off is loss of `ON DELETE CASCADE` (quota rows may orphan when a parent is deleted).

### This PR
Adds the registration entry only:
```yaml
- name: oarepo-feature-quota-drop-parent-fk
  base: v32.0.0
```
under `invenio-rdm-records › features`.