### PR TITLE
Remove obsolete feature from invenio-forks.yaml

### DIFF
--- a/invenio-forks.yaml
+++ b/invenio-forks.yaml
@@ -163,8 +163,6 @@ packages:
         base: v32.0.0
       - name: oarepo-feature-file-modification-uppy
         base: v32.0.0
-      - name: oarepo-feature-review-service-index-on-create
-        base: v23.0.0
     entrypoints:
       - remove:
           - group: invenio_search.mappings


### PR DESCRIPTION
Removed 'oareo-feature-review-service-index-on-create' entry.